### PR TITLE
relax dependencies on reflection and containers

### DIFF
--- a/karamaan-opaleye.cabal
+++ b/karamaan-opaleye.cabal
@@ -11,7 +11,7 @@ library
 
   build-depends:
       base               >= 4   && < 5
-    , containers         >= 0.4 && < 0.5
+    , containers         >= 0.4 && < 0.6
     , contravariant      >= 0.4 && < 0.5
     , karamaan-plankton  >= 0.1 && < 0.2
     , haskelldb          == 2.2.2.0.0.0.3
@@ -25,7 +25,7 @@ library
     , product-profunctors >= 0.4 && < 0.5
     , profunctors         >= 4.0 && < 4.1
       -- Just needed for the FromRow reification stuff
-    , reflection >= 1.3 && < 1.4
+    , reflection >= 1.3 && < 1.5
     , tagged     >= 0.7 && < 0.8
     , time       >= 1.4 && < 1.5
 


### PR DESCRIPTION
Based on other packages, I had both containers 0.5 and reflection > 1.4 installed. Relaxing these dependencies did not cause any compiler error, so I assume they were just done as the standard pattern of >= cur-major-version && < next-major-version.
