### PR TITLE
Remove extra parentheses after RETURNING

### DIFF
--- a/Karamaan/Opaleye/HaskellDB.hs
+++ b/Karamaan/Opaleye/HaskellDB.hs
@@ -13,7 +13,7 @@ ppInsertReturning :: SqlInsertReturning -> PP.Doc
 ppInsertReturning (SqlInsertReturning insert returnExprs) =
   P.ppInsert insert
   $$ PP.text "RETURNING"
-  <+> PP.parens (commaV P.ppSqlExpr returnExprs)
+  <+> commaV P.ppSqlExpr returnExprs
 
 -- TODO: this is from HaskellDB.Sql.Print, but they don't export it!
 -- Why oh why?


### PR DESCRIPTION
These change the returned values to be a packed in a record in a single column.
