### PR TITLE
Change ExprArr.constant* from Expr to ExprArr b.

### DIFF
--- a/Karamaan/Opaleye/ExprArr.hs
+++ b/Karamaan/Opaleye/ExprArr.hs
@@ -17,7 +17,6 @@ module Karamaan.Opaleye.ExprArr
     , plus
     , mul
     , constant
-    , constantRC
     , or
     , toQueryArr
     , toQueryArrDef
@@ -116,27 +115,24 @@ runExprArr'' expr (a, scope) = unsafeScopeLookup b scope1
 
 -- Note that the returned Scope value is what is *added* to the
 -- overall scope, so ignoring the incoming Scope here is not a bug!
-constantLit :: Literal -> Expr (Wire a)
+constantLit :: Literal -> ExprArr b (Wire a)
 constantLit l = ExprArr g
-  where g ((), _, t0) = (w, scope, next t0)
+  where g (_, _, t0) = (w, scope, next t0)
           where ws = tagWith t0 "constant"
                 w = Wire ws
                 scope = Map.singleton ws (PQ.ConstExpr l)
 
 -- Probably best just to use Karamaan.Opaleye.ShowConstant.showConstant
 -- these days.  constant may well be deprecated at some future point.
-constant :: ShowConstant a => a -> Expr (Wire a)
+constant :: ShowConstant a => a -> ExprArr b (Wire a)
 constant = constantLit . showConstant
-
-constantRC :: ShowConstant a => a -> ExprArr b (Wire a)
-constantRC = replaceWith . constant
 
 -- Probably best just to use Karamaan.Opaleye.ShowConstant.showConstant
 -- these days.  constantDay will be deprecated at some point in the future.
-constantDay :: Day -> Expr (Wire Day)
+constantDay :: Day -> ExprArr b (Wire Day)
 constantDay = unsafeConstant . Values.dayToSQL
 
-unsafeConstant :: String -> Expr (Wire a)
+unsafeConstant :: String -> ExprArr b (Wire a)
 unsafeConstant = constantLit . PQ.OtherLit
 
 unsafeCoerce :: ExprArr (Wire a) (Wire b)

--- a/Karamaan/Opaleye/Nullable.hs
+++ b/Karamaan/Opaleye/Nullable.hs
@@ -52,5 +52,5 @@ toNullable = unsafeCoerce
 toNullableExpr :: E.ExprArr (Wire a) (Wire (Nullable a))
 toNullableExpr = E.unsafeCoerce
 
-null :: E.Expr (Wire (Nullable a))
+null :: E.ExprArr b (Wire (Nullable a))
 null = E.unsafeCoerce <<< E.constantLit PQ.NullLit

--- a/Karamaan/Opaleye/ShowConstant.hs
+++ b/Karamaan/Opaleye/ShowConstant.hs
@@ -30,7 +30,7 @@ import System.Locale (defaultTimeLocale)
 -}
 
 class ShowConstant haskell opaleye where
-  showConstant :: haskell -> E.Expr (Wire opaleye)
+  showConstant :: haskell -> E.ExprArr a (Wire opaleye)
 
 instance ShowConstant haskell opaleye
          => ShowConstant (Maybe haskell) (N.Nullable opaleye) where
@@ -73,5 +73,5 @@ instance ShowConstant UUID UUID where
 --   instance ShowConstant X X where
 --     showConstant = showThrough unX
 -- @
-showThrough :: forall a b. ShowConstant a a => (b -> a) -> b -> E.Expr (Wire b)
-showThrough f = fmap unsafeCoerce . (showConstant :: a -> E.Expr (Wire a)) . f
+showThrough :: forall a b c. ShowConstant a a => (b -> a) -> b -> E.ExprArr c (Wire b)
+showThrough f = fmap unsafeCoerce . (showConstant :: a -> E.ExprArr c (Wire a)) . f

--- a/karamaan-opaleye.cabal
+++ b/karamaan-opaleye.cabal
@@ -14,7 +14,7 @@ library
     , containers         >= 0.4 && < 0.6
     , contravariant      >= 0.4 && < 1.2
     , karamaan-plankton  >= 0.1 && < 0.4
-    , haskelldb          == 2.2.2.0.0.0.3
+    , haskelldb          == 2.2.3
       -- vv mtl just for the State monad in Values.
       -- Remove this dependency when we write our own monad.
     , mtl >= 2.1 && < 2.3


### PR DESCRIPTION
There's no reason to restrict the input to (), and it disallows using
these function in contexts where two arrows of the same input type are
required (e.g. (&&&)).
