### PR TITLE
Num instance exprarr

### DIFF
--- a/Karamaan/Opaleye/ExprArr.hs
+++ b/Karamaan/Opaleye/ExprArr.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE FlexibleContexts, DeriveFunctor #-}
+{-# LANGUAGE FlexibleContexts, DeriveFunctor, FlexibleInstances #-}
 
 module Karamaan.Opaleye.ExprArr
     ( Scope
@@ -43,6 +43,7 @@ module Karamaan.Opaleye.ExprArr
 
 import Control.Applicative (Applicative (..))
 import Prelude hiding (or, and, not, mod, abs, signum)
+import qualified Prelude
 import qualified Data.Map as Map
 import Data.Map (Map)
 import Database.HaskellDB.PrimQuery (PrimExpr, extend, Literal)
@@ -81,6 +82,14 @@ newtype ExprArr a b = ExprArr ((a, Scope, Tag) -> (b, Scope, Tag))
 instance Applicative (ExprArr a) where
   pure = arr . const
   f <*> x = arr (uncurry ($)) <<< (f &&& x)
+
+instance (Num b, ShowConstant b) => Num (ExprArr a (Wire b)) where
+  f + g    = plus   <<< (f &&& g)
+  f - g    = minus  <<< (f &&& g)
+  f * g    = mul    <<< (f &&& g)
+  abs    f = abs    <<< f
+  signum f = signum <<< f
+  fromInteger = constantRC . fromInteger
 
 type Expr b = ExprArr () b
 


### PR DESCRIPTION
I added a Num instance for `ExprArr a (Wire b)`. This makes writing expressions to restrict queries much nicer: constants are just number literals, and all numeric operations like (+) lose the dots. I'm a bit scared about what happens when you use other, derived functions using `Num`. Those might introduce quite large expressions, I guess. But I think it's worth it for the numeric literals alone.

Note that this builds on top of my relax-constant-exprs branch, since that is needed for the `fromIntegral` to type check.
