### PR TITLE
Implement orderBy.

### DIFF
--- a/Karamaan/Opaleye/Order.hs
+++ b/Karamaan/Opaleye/Order.hs
@@ -1,0 +1,82 @@
+{-# LANGUAGE FlexibleContexts, GeneralizedNewtypeDeriving #-}
+module Karamaan.Opaleye.Order (orderBy, orderByU, asc, desc, OrderSpec) where
+
+import Database.HaskellDB.PrimQuery ( PrimQuery (..), SpecialOp (..)
+                                    , OrderExpr (..), PrimExpr
+                                    , OrderOp (..)
+                                    )
+import Data.Functor.Contravariant (Contravariant (..))
+import Data.Monoid (Monoid)
+import Data.Profunctor.Product (PPOfContravariant)
+import Data.Profunctor.Product.Default (Default, cdef)
+import Karamaan.Opaleye.ExprArr (ExprArr, runExprArr'', Scope, scopeOfCols)
+import Karamaan.Opaleye.QueryArr (Query, simpleQueryArr, runSimpleQueryArr, Tag)
+import Karamaan.Opaleye.Unpackspec (Unpackspec)
+import Karamaan.Opaleye.Wire (Wire)
+
+{-|
+
+Order the rows of a `Query` according to the specifications in
+`OrderSpec`.
+
+-}
+orderBy :: Default (PPOfContravariant Unpackspec) a a => OrderSpec a -> Query a -> Query a
+orderBy = orderByU cdef
+
+{-|
+
+Order the rows of a `Query` like `orderBy`, but with an explicit `Unpackspec`.
+
+-}
+orderByU :: Unpackspec a -> OrderSpec a -> Query a -> Query a
+orderByU unpack oss a = simpleQueryArr (orderByU' unpack oss . runSimpleQueryArr a)
+
+orderByU' :: Unpackspec a -> OrderSpec a -> (a, PrimQuery, Tag) -> (a, PrimQuery, Tag)
+orderByU' unpack os (x, q, t) = (x, mkOrder, t)
+  where
+    mkOrder = Special (Order orderExprs) q
+    orderExprs = toOrderExprs unpack x os
+
+{- |
+
+An `OrderSpec` represents an expression to order on and a sort
+direction. Multiple ones can be composed with `Data.Monoid.mappend`.
+If two rows are equal according to the first `OrderSpec`, the second
+is used, and so on.
+
+-}
+newtype OrderSpec a = OrderSpec [SingleOrderSpec a] deriving Monoid
+
+instance Contravariant OrderSpec where
+  contramap f (OrderSpec oss) = OrderSpec $ map (contramap f) oss
+
+data SingleOrderSpec a = SingleOrderSpec OrderOp (a -> Scope -> PrimExpr)
+
+instance Contravariant SingleOrderSpec where
+  contramap f (SingleOrderSpec op g) = SingleOrderSpec op (g . f)
+
+toOrderExprs :: Unpackspec a -> a -> OrderSpec a -> [OrderExpr]
+toOrderExprs unpack x (OrderSpec oss) = map (toOrderExpr unpack x) oss
+
+toOrderExpr :: Unpackspec a -> a -> SingleOrderSpec a -> OrderExpr
+toOrderExpr unpack x (SingleOrderSpec dir f) = OrderExpr dir (f x scope)
+  where scope = scopeOfCols unpack x
+
+{- |
+
+Specify an ascending ordering by the given expression.
+
+-}
+asc :: ExprArr a (Wire b) -> OrderSpec a
+asc  = orderSpec OpAsc
+
+{- |
+
+Specify an descending ordering by the given expression.
+
+-}
+desc :: ExprArr a (Wire b) -> OrderSpec a
+desc = orderSpec OpDesc
+
+orderSpec :: OrderOp -> ExprArr a (Wire b) -> OrderSpec a
+orderSpec dir expr = OrderSpec [SingleOrderSpec dir (curry $ runExprArr'' expr)]

--- a/karamaan-opaleye.cabal
+++ b/karamaan-opaleye.cabal
@@ -50,6 +50,7 @@ library
                    Karamaan.Opaleye.Operators2,
                    Karamaan.Opaleye.OperatorsPrimatives,
                    Karamaan.Opaleye.Operators.Numeric,
+                   Karamaan.Opaleye.Order
                    Karamaan.Opaleye.Predicates,
                    Karamaan.Opaleye.QueryArr,
                    Karamaan.Opaleye.QueryColspec,


### PR DESCRIPTION
I've implemented `orderBy`, roughly according to `TODO.md`. I had to use an actual `Scope`, not an empty one, since the columns need to be looked up there. This also required a `Default (PPOfContraVariant Unpackspec)` instance. Would you also want the non-default versions?

I've also changed the API a little bit. The `Query` argument seemed redundant, it just required duplicating the `Category` composition. Also, `makeOrderSpec` seemed a bit verbose, I went with `asc` and `desc` instead. Feel free to suggest other names, or point out any changes you'd like regarding coding style and such, since I'm not sure exactly what you use.

I haven't thoroughly tested this, but examples like this work:

``` haskell
orderedPersons = orderBy [desc (2 * arr age), asc (arr address)] . personTable
```

This produces the following SQL:

``` sql
SELECT name as name_1,
       age as age_1,
       address as address_1
FROM persons as T1
ORDER BY 2 * (age) DESC,
         address ASC
```
