### PR TITLE
Changed the type returned by `count` from `Int` to `Int64`

### DIFF
--- a/Examples/Examples.lhs
+++ b/Examples/Examples.lhs
@@ -21,6 +21,7 @@
 > import Karamaan.Opaleye.SQL (showSqlForPostgresDefault)
 > import Control.Category ((<<<))
 > import Control.Arrow (arr, (&&&), returnA)
+> import Data.Int (Int64)
 > import Data.Time.Calendar (Day)
 >
 > import Data.Profunctor.Product.TH (makeAdaptorAndInstance)
@@ -427,13 +428,13 @@ Here we see the first explict use of our Template Haskell derived
 code.  We use the 'pWidget' "adaptor" to specify how columns are
 aggregated.  Note that this is yet another example of avoiding a
 headache by keeping your datatype fully polymorphic, because the
-'count' aggregator changes a 'Wire String' into a 'Wire Int'.
+'count' aggregator changes a 'Wire String' into a 'Wire Int64'.
 
 'aggregateWidgets' groups by the style and color of widgets,
 calculating how many (possibly duplicated) locations there are, the
 total number of such widgets and their average radius.
 
-> aggregateWidgets :: Query (Widget (Wire String) (Wire String) (Wire Int)
+> aggregateWidgets :: Query (Widget (Wire String) (Wire String) (Wire Int64)
 >                              (Wire Int) (Wire Double))
 > aggregateWidgets = aggregate (pWidget (Widget' { style    = groupBy
 >                                                , color    = groupBy

--- a/Karamaan/Opaleye/Aggregate.hs
+++ b/Karamaan/Opaleye/Aggregate.hs
@@ -39,6 +39,7 @@ import Data.Profunctor.Product (ProductProfunctor, empty, (***!),
 import Data.Functor.Contravariant (contramap)
 import Control.Applicative (Applicative, (<*>), pure)
 import Data.Monoid (mempty, (<>))
+import Data.Int (Int64)
 
 -- Maybe it would be safer if we combined the two writers into
 -- "LWriter (Maybe AggrOp, String) a"?  That way we'd know they output
@@ -116,7 +117,7 @@ groupBy = aggregatorMaker' Nothing
 
 -- | Count the amount of rows inside each @GROUP BY@ clause (or the entire table
 -- if no grouping was specified).
-count :: Aggregator (Wire a) (Wire Int)
+count :: Aggregator (Wire a) (Wire Int64)
 count = aggregatorMaker AggrCount
 
 stddev :: Aggregator (Wire a) (Wire a)


### PR DESCRIPTION
The PostgreSQL type of `count` is `bigint`
(http://www.postgresql.org/docs/9.1/static/functions-aggregate.html),
which `postgresql-simple` can convert to `Integer` or `Int64`, but not
`Int`.
